### PR TITLE
Update .travis.yml to use trusty distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
 - oraclejdk8
 addons:

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,6 @@ systemProp.sonar.links.ci=https://travis-ci.org/mrombout/Spiner
 systemProp.sonar.links.scm=https://github.com/mrombout/Spiner
 systemProp.sonar.links.issue=https://github.com/mrombout/Spiner/issues
 
-systemProp.sonar.host.url=https://sonarqube.com
+systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.organization=mrombout-github
 systemProp.sonar.login=4ebe347692756b47a96e18b269a3683a18127481


### PR DESCRIPTION
This might fix the issue that is currently breaking the builds on Travis.

$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"

Ignoring license option: BCL -- using GPLv2+CE by default

install-jdk.sh 2019-07-17

Expected feature release number in range of 9 to 14, but got: 8

The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .

https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/9