### PR TITLE
Ignore unrecognized or additional attributes when parsing Twine archive

### DIFF
--- a/Core/src/main/java/nl/mikero/spiner/core/twine/TwineArchiveParser.java
+++ b/Core/src/main/java/nl/mikero/spiner/core/twine/TwineArchiveParser.java
@@ -1,13 +1,12 @@
 package nl.mikero.spiner.core.twine;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.*;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
 
 import nl.mikero.spiner.core.exception.TwineParseFailedException;
 import nl.mikero.spiner.core.twine.model.ObjectFactory;
@@ -19,10 +18,17 @@ import org.xml.sax.SAXException;
  */
 public class TwineArchiveParser {
 
+    private static final List<String> IGNORED_ERRORS = Collections.singletonList("cvc-complex-type.3.2.2");
+
     /**
      * Parses a well-formed and valid Twine Archive XML file into a
      * {@link TwStoriesdata} tree.
      *
+     * It is somewhat lenient in regards to XML parsing and will ignore the following errors:
+     *
+     *  - cvc-complex-type.3.2.2
+     *
+     * @see https://github.com/apache/xerces2-j/blob/e5a239b96fd2cff6566a29e7a4a3a4a2bbf9b0d4/src/org/apache/xerces/impl/msg/XMLSchemaMessages.properties
      * @param inputStream input stream to read XML file from
      * @return unmarshalled xml object tree
      * @throws TwineParseFailedException when input could not be parsed
@@ -35,6 +41,7 @@ public class TwineArchiveParser {
             SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
             Schema schema = schemaFactory.newSchema(getClass().getResource("/format.xsd"));
             unmarshaller.setSchema(schema);
+            unmarshaller.setEventHandler(event -> IGNORED_ERRORS.stream().anyMatch(ignoredError -> event.getMessage().startsWith(ignoredError)));
 
             JAXBElement<TwStoriesdata> unmarshalledObject =
                     (JAXBElement<TwStoriesdata>) unmarshaller.unmarshal(inputStream);

--- a/Core/src/test/java/nl/mikero/spiner/core/twine/TwineArchiveParserTest.java
+++ b/Core/src/test/java/nl/mikero/spiner/core/twine/TwineArchiveParserTest.java
@@ -68,6 +68,20 @@ public class TwineArchiveParserTest {
         // Assert
     }
 
+    @Test
+    public void parse_ExtraAttributeInXmlFile_IgnoresAttribute() throws Exception {
+        // Arrange
+
+        // Act
+        TwStoriesdata result;
+        try(InputStream inputStream = getClass().getResourceAsStream("/xml/extra_attribute.xml")) {
+            result = parser.parse(inputStream);
+        }
+
+        // Assert
+        assertNotNull(result);
+    }
+
     @Test(expected = IOException.class)
     public void parse_InputDoesNotExist_ThrowsIOException() throws Exception {
         // Arrange

--- a/Core/src/test/resources/xml/extra_attribute.xml
+++ b/Core/src/test/resources/xml/extra_attribute.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<tw-storiesdata>
+    <tw-storydata name="MyEpubStory" startnode="1" creator="Twine" creator-version="2.0.4"
+                  ifid="25CF1964-B554-47F0-82E5-68E106A57774" format="TwineXML" options="" extra-attribute="is-ignored">
+        <style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style>
+        <script role="script" id="twine-user-script" type="text/twine-javascript"></script>
+        <tw-passagedata pid="1" name="intro" tags="test test2" position="942,313">Lorum ipsum dolor sit amet.
+            [[test|test_page]]
+        </tw-passagedata>
+        <tw-passagedata pid="2" name="test_page" tags="" position="942,464">Double-click this passage to edit it.
+        </tw-passagedata>
+    </tw-storydata>
+</tw-storiesdata>

--- a/Core/src/test/resources/xml/extra_element.xml
+++ b/Core/src/test/resources/xml/extra_element.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<tw-storiesdata>
+    <tw-storydata name="MyEpubStory" startnode="1" creator="Twine" creator-version="2.0.4"
+                  ifid="25CF1964-B554-47F0-82E5-68E106A57774" format="TwineXML" options="">
+        <style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style>
+        <script role="script" id="twine-user-script" type="text/twine-javascript"></script>
+        <extra-element></extra-element>
+        <tw-passagedata pid="1" name="intro" tags="test test2" position="942,313">Lorum ipsum dolor sit amet.
+            [[test|test_page]]
+        </tw-passagedata>
+        <tw-passagedata pid="2" name="test_page" tags="" position="942,464">Double-click this passage to edit it.
+        </tw-passagedata>
+    </tw-storydata>
+</tw-storiesdata>


### PR DESCRIPTION
This should make the parser a little less likely to break when Twine or a story format updates and adds a new attribute that Spiner doesn't recognize yet.

New errors could be added later, but this is the only one for now of which I am sure Spiner can handle.